### PR TITLE
Fixed Interior sell Bug

### DIFF
--- a/src/core/server/systems/interior.ts
+++ b/src/core/server/systems/interior.ts
@@ -754,7 +754,7 @@ export class InteriorSystem {
             return;
         }
 
-        value = Math.abs(value);
+        value = Math.floor(value);
 
         if (value > ONE_BILLION) {
             playerFuncs.emit.soundFrontend(player, 'Hack_Failed', 'DLC_HEIST_BIOLAB_PREP_HACKING_SOUNDS');


### PR DESCRIPTION
`value = Math.abs(value);` returns 1 when value is -1 making it impossible to sell.