### PR TITLE
Remove nonexistent tab from inventory structure

### DIFF
--- a/src/core/server/commands/inventory.ts
+++ b/src/core/server/commands/inventory.ts
@@ -27,7 +27,7 @@ ChatController.addCommand(
 );
 
 function clearInventory(player: alt.Player) {
-    player.data.inventory = new Array(6);
+    player.data.inventory = new Array(5);
     for (let i = 0; i < player.data.inventory.length; i++) {
         player.data.inventory[i] = [];
     }

--- a/src/core/server/extensions/playerFunctions/sync.ts
+++ b/src/core/server/extensions/playerFunctions/sync.ts
@@ -37,7 +37,7 @@ function appearance(player: alt.Player): void {
 
 function inventory(player: alt.Player): void {
     if (!player.data.inventory) {
-        player.data.inventory = new Array(6);
+        player.data.inventory = new Array(5);
         for (let i = 0; i < player.data.inventory.length; i++) {
             player.data.inventory[i] = [];
         }

--- a/src/webview/client/inventory/app.js
+++ b/src/webview/client/inventory/app.js
@@ -37,7 +37,7 @@ const app = new Vue({
          * @param {Array<Object>} items
          */
         updateInventory(inventoryItems) {
-            const newInventory = new Array(6);
+            const newInventory = new Array(5);
             for (let i = 0; i < newInventory.length; i++) {
                 newInventory[i] = new Array(28).fill(null);
             }
@@ -549,7 +549,7 @@ const app = new Vue({
         document.addEventListener('keyup', this.handleClose);
 
         // Used to populate data on entry.
-        this.inventory = new Array(6).fill(new Array(28).fill(null));
+        this.inventory = new Array(5).fill(new Array(28).fill(null));
         this.ground = new Array(8).fill(null);
         this.equipment = new Array(11).fill(null);
         this.toolbar = new Array(4).fill(null);


### PR DESCRIPTION
Inventory has 5 tabs. But Array was 6. Players could have items in a 6th non visible tab.