### PR TITLE
Add setOverlayVisible to WebViewController

### DIFF
--- a/src/core/client/extensions/view2.ts
+++ b/src/core/client/extensions/view2.ts
@@ -79,6 +79,23 @@ export class WebViewController {
     }
 
     /**
+     * Trigger this to hide/show a specific overlay
+     * @static
+     * @param {string} pageName
+     * @param {boolean} state
+     * @memberof WebViewController
+     */
+	static setOverlayVisible(pageName: string, state: boolean) {
+		const index = _overlays.findIndex((page) => page.name === pageName);
+
+		if (index === -1) {
+			return;
+		}
+
+		_overlays[index].callback(state);
+	}
+    
+    /**
      * Get the current WebView instance.
      * @static
      * @return {Promise<alt.WebView>}


### PR DESCRIPTION
Maybe it's someone who doesn't want to hide all the overlays, and just wants to hide the chat, for example, or whatever.

Usage:
```ts
// hide the overlay
WebViewController.setOverlayVisible('Chat', false);

// show the overlay
WebViewController.setOverlayVisible('Chat', true);
```