### PR TITLE
Fix: Vehicles are not respawnable on server restart

### DIFF
--- a/src/core/server-plugins/core-garage/src/view.ts
+++ b/src/core/server-plugins/core-garage/src/view.ts
@@ -133,7 +133,7 @@ export class GarageFunctions {
                 );
 
                 if (!existingVehicle) {
-                    return false;
+                    return true;
                 }
 
                 // The vehicle exists and may or may not be in a parking space


### PR DESCRIPTION
Fixesvehicles not showing up inside garage menu when `SPAWN_ALL_VEHICLES_ON_START` is set to `false` preventing vehicles from being parked out on server restart