### PR TITLE
Resolve Character Creator moving character while using input

### DIFF
--- a/src/core/plugins/core-character-creator/webview/CharacterCreator.vue
+++ b/src/core/plugins/core-character-creator/webview/CharacterCreator.vue
@@ -83,6 +83,7 @@ export default defineComponent({
             show: false,
             selection: 0,
             forceUpdate: 0,
+            controlsEnabled: true,
             data: {
                 sex: 1,
                 faceMother: 0,
@@ -158,12 +159,22 @@ export default defineComponent({
             }
 
             this.selection += 1;
+
+            if(this.selection >= this.navOptions.length - 1 && this.controlsEnabled) {
+                alt.emit(CHARACTER_CREATOR_WEBVIEW_EVENTS.DISABLE_CONTROLS, true);
+                this.controlsEnabled = false;
+            }
         },
         decrementIndex() {
             if (this.selection - 1 <= -1) {
                 this.selection = 0;
                 return;
             }
+            
+            if(!this.controlsEnabled) {
+                alt.emit(CHARACTER_CREATOR_WEBVIEW_EVENTS.DISABLE_CONTROLS, false);
+                this.controlsEnabled = true;
+            } 
 
             this.selection -= 1;
         },


### PR DESCRIPTION
Only useable on the first 4 pages so you can still move the camera while editing the character, game controls are blocked on last index, so you cannot move the character by typing into the inputs.