### PR TITLE
temporary disabled area name display in vehicle

### DIFF
--- a/src/core/client/events/connectionComplete.ts
+++ b/src/core/client/events/connectionComplete.ts
@@ -22,6 +22,9 @@ async function handleConnectionComplete() {
 
 alt.everyTick(() => {
     native.hideHudComponentThisFrame(6); // Vehicle Name
+    if (alt.Player.local.vehicle) {
+        native.hideHudComponentThisFrame(7); // Area Name
+    }
     native.hideHudComponentThisFrame(8); // Vehicle Class
     native.hideHudComponentThisFrame(9); // Street Name
 });


### PR DESCRIPTION
temporary disabled area name display in vehicle, because the text is under the hud and not really readable.