### PR TITLE
remove check vehicle has no data from hasOwnership function

### DIFF
--- a/src/core/server/extensions/vehicleFuncs.ts
+++ b/src/core/server/extensions/vehicleFuncs.ts
@@ -505,10 +505,6 @@ export default class VehicleFuncs {
             return true;
         }
 
-        if (!vehicle.data) {
-            return true;
-        }
-
         // Check Actual Ownership
         if (vehicle.data.owner === player.data._id.toString()) {
             return true;


### PR DESCRIPTION
If the player does not have the same player id as the vehicle but the vehicle does not have vehicle.data, he can still unlock the vehicle from other players e.g. at the example jobs.