### PR TITLE
Fixed destroyed pillbox hill hospital

### DIFF
--- a/src/core/client/systems/interiors.ts
+++ b/src/core/client/systems/interiors.ts
@@ -128,11 +128,7 @@ function fixMissingInteriors() {
     alt.requestIpl('Jetsteal_ipl_grp1');
 
     // Hospital Pillbox Interiors
-    alt.requestIpl('v_hospital');
-    alt.removeIpl('RC12B_Default');
-    alt.removeIpl('RC12B_Fixed');
-    alt.requestIpl('RC12B_Destroyed');
-    alt.requestIpl('RC12B_HospitalInterior');
+    alt.requestIpl('RC12B_Default');
 
     // Canyon
     alt.requestIpl('canyonriver01');


### PR DESCRIPTION
This fixes the destroyed pillbox hill hospital which is imho a better default setting for a hospital in the middle of the city. But I think that's a matter of taste, it's just a suggestion.

Before:
![Grand Theft Auto V Screenshot 2022 06 18 - 16 18 04 64](https://user-images.githubusercontent.com/40345051/174444875-ed060611-f6f3-459a-be0e-ece3e1301c4a.png)

After:
![Grand Theft Auto V Screenshot 2022 06 18 - 16 55 22 12](https://user-images.githubusercontent.com/40345051/174444882-c46f09ee-bded-4e95-b8b0-246f0628050a.png)

