### PR TITLE
Changeable permission-strategy for chat-commands

### DIFF
--- a/src/core/server/systems/chat.ts
+++ b/src/core/server/systems/chat.ts
@@ -119,7 +119,8 @@ class InternalFunctions {
         }
 
         if (commandInfo.permission) {
-            const isAdminPermissionValid = isFlagEnabled(player.accountData.permissionLevel, commandInfo.permission);
+            const isAdminPermissionValid = Permission.isPermissionValidByStrategy(player.accountData.permissionLevel,
+                commandInfo.permission);
 
             if (!isAdminPermissionValid) {
                 Athena.player.emit.message(
@@ -139,10 +140,8 @@ class InternalFunctions {
                 return;
             }
 
-            const isCharacterPermValid = isFlagEnabled(
-                player.data.characterPermission,
-                commandInfo.characterPermissions,
-            );
+            const isCharacterPermValid = Permission.isPermissionValidByStrategy(player.data.characterPermission,
+                commandInfo.characterPermissions);
 
             if (!isCharacterPermValid) {
                 Athena.player.emit.message(
@@ -304,10 +303,8 @@ export default class ChatController {
 
             // Check Admin Permission Commands
             if (commandInfo.permission) {
-                const isAdminPermissionValid = isFlagEnabled(
-                    player.accountData.permissionLevel,
-                    commandInfo.permission,
-                );
+                const isAdminPermissionValid = Permission.isPermissionValidByStrategy(player.accountData.permissionLevel,
+                    commandInfo.permission);
 
                 if (!isAdminPermissionValid) {
                     return;
@@ -327,10 +324,8 @@ export default class ChatController {
                     return;
                 }
 
-                const isCharacterPermValid = isFlagEnabled(
-                    player.data.characterPermission,
-                    commandInfo.characterPermissions,
-                );
+                const isCharacterPermValid = Permission.isPermissionValidByStrategy(player.data.characterPermission,
+                    commandInfo.characterPermissions)
                 if (!isCharacterPermValid) {
                     return;
                 }

--- a/src/core/server/systems/chat.ts
+++ b/src/core/server/systems/chat.ts
@@ -12,6 +12,7 @@ import { Athena } from '../api/athena';
 import { DEFAULT_CONFIG } from '../athena/main';
 import { consoleCommand } from '../decorators/commands';
 import { emitAll } from '../utility/emitHelper';
+import {Permission} from "./permission";
 
 const maxMessageLength: number = 128;
 const printCommands = false;

--- a/src/core/server/systems/permission.ts
+++ b/src/core/server/systems/permission.ts
@@ -1,0 +1,54 @@
+import * as alt from 'alt-server';
+import {ATHENA_EVENTS_PLAYER} from '../../shared/enums/athenaEvents';
+import {PLAYER_SYNCED_META} from '../../shared/enums/playerSynced';
+import {PlayerEvents} from '../events/playerEvents';
+import {isFlagEnabled} from "../../shared/utility/flags";
+import {PERMISSIONS} from "../../shared/flags/permissionFlags";
+
+type PermissionStrategy = 'matching_roles' | 'inherited_roles';
+
+let strategy: PermissionStrategy = 'matching_roles';
+
+export class Permission {
+
+    /**
+     * Should be set during the server startup phase to change player permission strategies.
+     * This will apply to all players when they select a character.
+     * DO NOT CHANGE THIS AFTER SERVER STARTUP.
+     *
+     * @static
+     * @param {PermissionStrategy} _strategy
+     * @memberof Permission
+     */
+    static setPermissionStrategy(_strategy: PermissionStrategy) {
+        strategy = _strategy;
+    }
+
+    /**
+     * Returns if permission is granted based on current strategy.
+     *
+     * @static
+     * @param {Permissions} permission
+     * @param {Permissions} permissionToCheck
+     * @return {boolean}
+     * @memberof Permission
+     */
+    static isPermissionValidByStrategy(permission: Permissions | number, permissionToCheck: Permissions | number): boolean {
+
+        if (strategy === 'matching_roles') {
+            return isFlagEnabled(
+                permission,
+                permissionToCheck,
+            );
+        }
+
+        if (strategy === 'inherited_roles') {
+            if (permission >= permissionToCheck) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+


### PR DESCRIPTION
Adding the ability to have a Superadmin use every command with "lower" roles below him (inherited rights)