### PR TITLE
Add `KeyHeld.unregister` method and make register and unregister callbacks optional

### DIFF
--- a/src/core/client/events/keyHeld.ts
+++ b/src/core/client/events/keyHeld.ts
@@ -58,6 +58,48 @@ export class KeyHeld {
 
         alt.log(`${String.fromCharCode(key)} | Was Registered in KeyHeld`);
     }
+
+    /**
+     * Use https://keycode.info for proper key numbers.
+     *
+     * @static
+     * @param {number} key
+     * @param {Function} onKeyDown Handle to the onKeyDown callback used in the register method call.
+     * @param {Function} onKeyUp Handle to the onKeyUp callback used in the register method call.
+     * @return {void}
+     * @memberof KeyHeld
+     */
+    static unregister(key: number, onKeyDown: Function, onKeyUp: Function): void {
+        // Verify a key is passed
+        if (typeof key === 'undefined') {
+            alt.logError(`Key was not specified for KeyHeld.unregister`);
+            return;
+        }
+
+        // Verify functions have values
+        if (typeof onKeyDown !== 'function' || typeof onKeyUp !== 'function') {
+            alt.logWarning(`${key} in KeyHeld.unregister does not have valid callback functions.`);
+            return;
+        }
+
+        if (!holdableKeys[key]) {
+            return;
+        }
+
+        const keyUpExists = holdableKeys[key].onKeyUp === onKeyUp;
+        const keyDownExists = holdableKeys[key].onKeyDown === onKeyDown;
+
+        if (keyUpExists && keyDownExists) {
+            delete holdableKeys[key];
+            return;
+        }
+
+        if (keyUpExists) {
+            delete holdableKeys[key].onKeyUp;
+        } else if (keyDownExists) {
+            delete holdableKeys[key].onKeyDown;
+        }
+    }
 }
 
 KeyHeld.init();


### PR DESCRIPTION
Helps https://github.com/Stuyk/altv-athena/pull/262#pullrequestreview-1079627523 to re-register keybinds - even tho you don't nessesarily need it because `KeyHeld.register` overwrites existing handlers anyway.

Also makes no sense to require both, keyDown and an keyUp callback because it's not always needed.