### PR TITLE
Don't allow Button to use @ click events when disabled

### DIFF
--- a/src-webviews/src/css/button.css
+++ b/src-webviews/src/css/button.css
@@ -21,6 +21,7 @@
 .disable {
     color: rgba(255, 255, 255, 0.2) !important;
     cursor: unset !important;
+    pointer-events: none;
 }
 
 .disable:active {


### PR DESCRIPTION
This will remove Button `@click` triggers when Button has `:disable="true"` and other click animations if are