### PR TITLE
[Core-Factions] : Added Faction Type for better overview.

### DIFF
--- a/src/core/plugins/core-factions/server/src/commands.ts
+++ b/src/core/plugins/core-factions/server/src/commands.ts
@@ -20,13 +20,14 @@ export class FactionCommands {
      * @param {string[]} name - The name of the faction.
      * @returns The result of the add function.
      */
-    @command('fcreate', '/fcreate [name] - Open faction panel if in faction.', PERMISSIONS.ADMIN)
-    private static async handleFactionCreate(player: alt.Player, ...name: string[]) {
+    @command('fcreate', '/fcreate [type: (Neutral, State, Gang)] [name] - Open faction panel if in faction.', PERMISSIONS.ADMIN)
+    private static async handleFactionCreate(player: alt.Player, type: string, ...name: string[]) {
         const factionName = name.join(' ');
         const result = await FactionHandler.add(player.data._id.toString(), {
             bank: 0,
             canDisband: true,
             name: factionName,
+            type: type.toUpperCase()
         });
 
         if (!result.status) {

--- a/src/core/plugins/core-factions/server/src/handler.ts
+++ b/src/core/plugins/core-factions/server/src/handler.ts
@@ -35,6 +35,18 @@ class InternalFunctions {
 
 export class FactionHandler {
     /**
+     * Faction Types.
+     * Gang can do crime actions.
+     * Neutral is Neutral.
+     * State can do state actions ( arrest, cuff people, etc. )
+     */
+    static factionTypes = {
+        gang: 'GANG',
+        neutral: 'NEUTRAL',
+        state: 'STATE'
+    }
+
+    /**
      * Initialize Factions on Startup
      *
      * @static
@@ -69,6 +81,11 @@ export class FactionHandler {
         if (!_faction.name) {
             alt.logWarning(`Cannot create faction, missing faction name.`);
             return { status: false, response: `Cannot create faction, missing faction name.` };
+        }
+
+        if (!this.factionTypes[_faction.type]) {
+            alt.logWarning('Cannot find faction-type ' + _faction.type + '! Type will be now ' + this.factionTypes.neutral);
+            _faction.type = this.factionTypes.neutral;
         }
 
         if (_faction.bank === null || _faction.bank === undefined) {

--- a/src/core/plugins/core-factions/shared/interfaces.ts
+++ b/src/core/plugins/core-factions/shared/interfaces.ts
@@ -226,6 +226,15 @@ export interface FactionCore {
      * @memberof Faction
      */
     canDisband: boolean;
+
+
+    /**
+     * Faction Type (gang, neutral, state)
+     *
+     * @type {string}
+     * @memberof Faction
+     */
+    type: string;
 }
 
 export interface FactionStorage {


### PR DESCRIPTION
This code will add `type` as a parameter for /fcreate.
This will be needed for future systems ( like arrest systems, gangwar systems etc - to check what kind of faction it is without using the faction ID. )