### PR TITLE
[Root]: Added default color for factions + added two new types.

### DIFF
--- a/src/core/plugins/core-factions/server/src/commands.ts
+++ b/src/core/plugins/core-factions/server/src/commands.ts
@@ -20,14 +20,15 @@ export class FactionCommands {
      * @param {string[]} name - The name of the faction.
      * @returns The result of the add function.
      */
-    @command('fcreate', '/fcreate [type: (Neutral, State, Gang)] [name] - Open faction panel if in faction.', PERMISSIONS.ADMIN)
+    @command('fcreate', '/fcreate [type: (Neutral, State, Gang, Medic, Mechanic)] [name] - Open faction panel if in faction.', PERMISSIONS.ADMIN)
     private static async handleFactionCreate(player: alt.Player, type: string, ...name: string[]) {
         const factionName = name.join(' ');
         const result = await FactionHandler.add(player.data._id.toString(), {
             bank: 0,
             canDisband: true,
             name: factionName,
-            type: type.toUpperCase()
+            type: type.toUpperCase(),
+            color: { r: 255, g: 255, b: 255, a: 255 }
         });
 
         if (!result.status) {

--- a/src/core/plugins/core-factions/server/src/handler.ts
+++ b/src/core/plugins/core-factions/server/src/handler.ts
@@ -43,7 +43,9 @@ export class FactionHandler {
     static factionTypes = {
         gang: 'GANG',
         neutral: 'NEUTRAL',
-        state: 'STATE'
+        state: 'STATE',
+        mechanic: 'MECHANIC',
+        medic: 'MEDIC'
     }
 
     /**

--- a/src/core/plugins/core-factions/shared/interfaces.ts
+++ b/src/core/plugins/core-factions/shared/interfaces.ts
@@ -235,6 +235,14 @@ export interface FactionCore {
      * @memberof Faction
      */
     type: string;
+
+    /**
+     * Faction Color
+     *
+     * @type {Color}
+     * @memberof Faction
+     */
+    color: Color;
 }
 
 export interface FactionStorage {

--- a/src/core/plugins/core-factions/shared/typings/color.d.ts
+++ b/src/core/plugins/core-factions/shared/typings/color.d.ts
@@ -1,0 +1,6 @@
+type Color = {
+    r: number;
+    g: number;
+    b: number;
+    a: number;
+}


### PR DESCRIPTION
This will add a default color for factions + the new types `medic` & `mechanic`.
The color PR will be needed for the color palette in the /fopen window ( in the next FR ) ( for faction chat color, gangwar, etc etc. )