### PR TITLE
Restrict drops to players dimension

### DIFF
--- a/src/core/server/streamers/item.ts
+++ b/src/core/server/streamers/item.ts
@@ -21,7 +21,8 @@ class InternalController {
     }
 
     static update(player: alt.Player, drops: Array<GroundItem>) {
-        alt.emitClient(player, SYSTEM_EVENTS.POPULATE_ITEM_DROPS, drops);
+        const dropsInPlayersDimension = drops.filter((item) => item.item.dimension === player.dimension);
+        alt.emitClient(player, SYSTEM_EVENTS.POPULATE_ITEM_DROPS, dropsInPlayersDimension);
     }
 }
 


### PR DESCRIPTION
The player can currently pick up items from another dimension even if he cannot see them. The change ensures that the player only receives items from his current dimension.