### PR TITLE
Handsover Object's Item to WheelMenu Injections

### DIFF
--- a/src/core/client/menus/object.ts
+++ b/src/core/client/menus/object.ts
@@ -4,11 +4,13 @@ import { distance } from '../../shared/utility/vector';
 import { isAnyMenuOpen } from '../utility/menus';
 import { IWheelOptionExt } from '../../shared/interfaces/wheelMenu';
 import { WheelMenu } from '../views/wheelMenu';
+import { GroundItem } from '../../shared/interfaces/groundItem';
 
 type ObjectMenuInjection = (
     modelHash: number,
     scriptID: number,
     options: Array<IWheelOptionExt>,
+    item?: GroundItem,
 ) => Array<IWheelOptionExt>;
 
 const Injections: Array<ObjectMenuInjection> = [];
@@ -47,7 +49,7 @@ const ObjectWheelMenuConst = {
      * @return {*}
      * @memberof ObjectWheelMenu
      */
-    openMenu(scriptID: number): void {
+    openMenu(scriptID: number, item?: GroundItem): void {
         if (isAnyMenuOpen()) {
             return;
         }
@@ -68,7 +70,7 @@ const ObjectWheelMenuConst = {
 
         for (const callback of Injections) {
             try {
-                options = callback(hash, scriptID, options);
+                options = callback(hash, scriptID, options, item);
             } catch (err) {
                 console.warn(`Got Object Menu Injection Error: ${err}`);
                 continue;

--- a/src/core/client/systems/interaction.ts
+++ b/src/core/client/systems/interaction.ts
@@ -236,12 +236,12 @@ export class InteractionController {
                 if (isValid) {
                     const targetCoords = native.getEntityCoords(closestTarget.scriptID, false);
                     let item = null;
-                    for (const closesItem of closestItems) {
-                        if (closesItem.item && closesItem.item.item && closesItem.item.item.model) {
-                            const itemHash = alt.hash(closesItem.item.item.model);
-                            const itemDistance = parseFloat(distance(targetCoords, closesItem.pos).toFixed(2));
+                    for (const closestItem of closestItems) {
+                        if (closestItem.item && closestItem.item.item && closestItem.item.item.model) {
+                            const itemHash = alt.hash(closestItem.item.item.model);
+                            const itemDistance = parseFloat(distance(targetCoords, closestItem.pos).toFixed(2));
                             if (hash === itemHash && itemDistance <= 0.7) {
-                                item = closesItem;
+                                item = closestItem;
                                 break;
                             }
                         }

--- a/src/core/client/systems/interaction.ts
+++ b/src/core/client/systems/interaction.ts
@@ -8,6 +8,7 @@ import keyboardMap from '../../shared/information/keyboardMap';
 import IClientInteraction from '../../shared/interfaces/iClientInteraction';
 import { Interaction } from '../../shared/interfaces/interaction';
 import { IWheelOptionExt } from '../../shared/interfaces/wheelMenu';
+import { distance } from '../../shared/utility/vector';
 import { KeybindController } from '../events/keyup';
 import { NpcWheelMenu } from '../menus/npc';
 import { ObjectWheelMenu } from '../menus/object';
@@ -230,15 +231,28 @@ export class InteractionController {
 
             // Object Type
             if (closestTarget.type === 'object') {
-                const hash = native.getEntityModel(closestTarget.scriptID);
+                const hash = native.getEntityModel(closestTarget.scriptID);                
                 const isValid = ObjectWheelMenu.isModelValidObject(hash);
                 if (isValid) {
+                    const targetCoords = native.getEntityCoords(closestTarget.scriptID, false);
+                    let item = null;
+                    for (const closesItem of closestItems) {
+                        if (closesItem.item && closesItem.item.item && closesItem.item.item.model) {
+                            const itemHash = alt.hash(closesItem.item.item.model);
+                            const itemDistance = parseFloat(distance(targetCoords, closesItem.pos).toFixed(2));
+                            if (hash === itemHash && itemDistance <= 0.7) {
+                                item = closesItem;
+                                break;
+                            }
+                        }
+                    }
+
                     wheelOptions.push({
                         name: `Object`,
                         icon: 'icon-lightbulb',
                         data: [closestTarget.scriptID],
                         callback: (scriptID: number) => {
-                            ObjectWheelMenu.openMenu(scriptID);
+                            ObjectWheelMenu.openMenu(scriptID, item);
                         },
                     });
                 }


### PR DESCRIPTION
The GroundItem (if exists) of a selected object will be transfert to the ObjectWheelMenu as optional parameter. This allows you to add menu entries related to the item instead to the object. 

Just a small example use case: Place an "water dispenser" on the ground. In the "water dispenser"-Item is the water level saved. The ObjectWheelMenu gives you an Option to "Drink". But if the the dispenser is empty the option should be no longer available.

