### PR TITLE
Set position of vehicle if player is driver

### DIFF
--- a/src/core/server/extensions/playerFunctions/safe.ts
+++ b/src/core/server/extensions/playerFunctions/safe.ts
@@ -16,8 +16,13 @@ const Safe = {
             player.model = `mp_m_freemode_01`;
         }
 
-        player.acPosition = new alt.Vector3(x, y, z);
-        player.pos = new alt.Vector3(x, y, z);
+        const pos = new alt.Vector3(x, y, z);
+        if (player.vehicle && player.vehicle.driver === player) {
+            player.vehicle.pos = pos;
+        } else {
+            player.acPosition = pos;
+            player.pos = pos;
+        }
     },
     /**
      * Safely add health to this player.


### PR DESCRIPTION
Small edit to `Safe.setPosition` where it set the position of the vehicle if the player is in one and is driver instead of setting the player position only.

Tested and works in city and even on mountain.