### PR TITLE
speedo knots display

### DIFF
--- a/src/core/plugins/core-hud/client/index.ts
+++ b/src/core/plugins/core-hud/client/index.ts
@@ -16,6 +16,7 @@ import { isAnyMenuOpen } from '@AthenaClient/utility/menus';
 import { KeyHeld } from '@AthenaClient/events/keyHeld';
 import { VehicleData } from '../../../shared/information/vehicles';
 import { isVehicleType, VEHICLE_TYPE } from '../../../shared/enums/vehicleTypeFlags';
+import { SHARED_CONFIG } from '@AthenaShared/configurations/shared';
 
 const SWITCH_KEY = 113; // F2
 const PAGE_NAME = 'Hud';
@@ -236,7 +237,10 @@ class InternalFunctions implements ViewModel {
 
         const data = VehicleData.find((dat) => alt.hash(dat.name) === alt.Player.local.vehicle.model);
 
-        if (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT)) {
+        if (
+            SHARED_CONFIG.ENABLE_KNOTS_FOR_BOATS_AND_AIRCRAFT &&
+            (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT))
+        ) {
             speedCalc = (currentSpeed * 1.943844).toFixed(0);
         } else {
             speedCalc = (currentSpeed * (isMetric ? 3.6 : 2.236936)).toFixed(0);
@@ -257,7 +261,10 @@ class InternalFunctions implements ViewModel {
 
         let unit: string;
 
-        if (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT)) {
+        if (
+            SHARED_CONFIG.ENABLE_KNOTS_FOR_BOATS_AND_AIRCRAFT &&
+            (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT))
+        ) {
             unit = 'kn';
         } else {
             if (native.getProfileSetting(227) === 1) {

--- a/src/core/plugins/core-hud/client/index.ts
+++ b/src/core/plugins/core-hud/client/index.ts
@@ -14,6 +14,8 @@ import { AthenaClient } from '@AthenaClient/api/athena';
 import { KeybindController } from '@AthenaClient/events/keyup';
 import { isAnyMenuOpen } from '@AthenaClient/utility/menus';
 import { KeyHeld } from '@AthenaClient/events/keyHeld';
+import { VehicleData } from '../../../shared/information/vehicles';
+import { isVehicleType, VEHICLE_TYPE } from '../../../shared/enums/vehicleTypeFlags';
 
 const SWITCH_KEY = 113; // F2
 const PAGE_NAME = 'Hud';
@@ -146,6 +148,7 @@ class InternalFunctions implements ViewModel {
         HudView.registerComponent(HUD_COMPONENT.IS_IN_VEHICLE, InternalFunctions.defaultIsInVehicleComponent, 1000);
         HudView.registerComponent(HUD_COMPONENT.SEATBELT, InternalFunctions.defaultSeatbeltComponent, 100);
         HudView.registerComponent(HUD_COMPONENT.SPEED, InternalFunctions.defaultSpeedComponent, 100);
+        HudView.registerComponent(HUD_COMPONENT.SPEED_UNIT, InternalFunctions.defaultSpeedUnitComponente);
         HudView.registerComponent(HUD_COMPONENT.GEAR, InternalFunctions.defaultGearComponent, 100);
         HudView.registerComponent(HUD_COMPONENT.ENGINE, InternalFunctions.defaultEngineComponent, 100);
         HudView.registerComponent(HUD_COMPONENT.LOCK, InternalFunctions.defaultLockComponent, 100);
@@ -228,12 +231,43 @@ class InternalFunctions implements ViewModel {
 
         const isMetric = native.getProfileSetting(227);
         const currentSpeed = native.getEntitySpeed(alt.Player.local.vehicle.scriptID);
-        const speedCalc = (currentSpeed * (isMetric ? 3.6 : 2.236936)).toFixed(0);
+
+        let speedCalc: string;
+
+        const data = VehicleData.find((dat) => alt.hash(dat.name) === alt.Player.local.vehicle.model);
+
+        if (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT)) {
+            speedCalc = (currentSpeed * 1.943844).toFixed(0);
+        } else {
+            speedCalc = (currentSpeed * (isMetric ? 3.6 : 2.236936)).toFixed(0);
+        }
+
         InternalFunctions.passComponentInfo(propName, parseInt(speedCalc));
     }
 
     static defaultMetricComponent(propName: string) {
         InternalFunctions.passComponentInfo(propName, native.getProfileSetting(227) === 1);
+    }
+
+    static defaultSpeedUnitComponente(propName: string) {
+        const data = VehicleData.find((dat) => alt.hash(dat.name) === alt.Player.local.vehicle.model);
+        if (!data) {
+            return;
+        }
+
+        let unit: string;
+
+        if (isVehicleType(data.type, VEHICLE_TYPE.AIRCRAFT) || isVehicleType(data.type, VEHICLE_TYPE.BOAT)) {
+            unit = 'kn';
+        } else {
+            if (native.getProfileSetting(227) === 1) {
+                unit = 'KM/H';
+            } else {
+                unit = 'MPH';
+            }
+        }
+
+        InternalFunctions.passComponentInfo(propName, unit);
     }
 
     static defaultIsInVehicleComponent(propName: string) {

--- a/src/core/plugins/core-hud/webview/Hud.vue
+++ b/src/core/plugins/core-hud/webview/Hud.vue
@@ -22,7 +22,7 @@
             <Icon :shadow="false" class="hidden-icon" icon="icon-eye" :size="32" />
         </div>
         <div class="speedo-placement" v-if="isInVehicle && hudState !== hudStateNames.HIDDEN">
-            <Speed :isMetric="isMetric" :speed="speed" :gear="gear" />
+            <Speed :unit="unit" :speed="speed" :gear="gear" />
             <div class="vehicle-bars">
                 <Engine :status="engine" />
                 <Seatbelt :status="seatbelt" />
@@ -82,6 +82,7 @@ export default defineComponent({
             seatbelt: false,
             isMetric: true,
             isInVehicle: false,
+            unit: 'KN',
             interactions: [] as Array<{ keyPress: string; description: string }>,
             updateCount: 0,
             hudState: 'hud',

--- a/src/core/plugins/core-hud/webview/components/Speed.vue
+++ b/src/core/plugins/core-hud/webview/components/Speed.vue
@@ -10,7 +10,7 @@
         </div>
     </div>
     <div class="speed-type speed-font-style">
-        {{ isMetric ? 'KMH' : 'MPH' }}
+        {{ unit }}
     </div>
     <div class="gear speed-font-style">
         {{ gear }}
@@ -31,8 +31,8 @@ export default defineComponent({
             type: Number,
             required: true,
         },
-        isMetric: {
-            type: Boolean,
+        unit: {
+            type: String,
             required: true,
         },
         gear: {

--- a/src/core/shared/configurations/shared.ts
+++ b/src/core/shared/configurations/shared.ts
@@ -16,4 +16,6 @@ export const SHARED_CONFIG = {
     USE_24H_TIME_FORMAT: false,
     // Idle Cam
     DISABLE_IDLE_CAM: false,
+    // This enables knots as unit for speed for Boats and Aircrafts
+    ENABLE_KNOTS_FOR_BOATS_AND_AIRCRAFT: false,
 };

--- a/src/core/shared/enums/hudComponents.ts
+++ b/src/core/shared/enums/hudComponents.ts
@@ -13,6 +13,7 @@ export enum HUD_COMPONENT {
     IS_IN_VEHICLE = 'isInVehicle',
     SEATBELT = 'seatbelt',
     SPEED = 'speed',
+    SPEED_UNIT = 'unit',
     GEAR = 'gear',
     ENGINE = 'engine',
     LOCK = 'lock',


### PR DESCRIPTION
If wanted a config entry allows the HUD-Speedometer to displays the speed in knots (KN) if you're in a boat or aircraft.

The process of determining the unit was moved from the webview itself to the client index file.