### PR TITLE
Update wheelMenu.ts

### DIFF
--- a/src/core/client/views/wheelMenu.ts
+++ b/src/core/client/views/wheelMenu.ts
@@ -83,7 +83,7 @@ class InternalFunctions implements ViewModel {
         view.off(VIEW_EVENTS_WHEEL_MENU.EXECUTE, InternalFunctions.execute);
 
         if (closePage) {
-            WebViewController.closePages([PAGE_NAME], true);
+            await WebViewController.closePages([PAGE_NAME], true);
         }
 
         WebViewController.unfocus();


### PR DESCRIPTION
When using wheel menu for interaction with NPC, when i choice NPC in interaction menu item which has own menu options first menu closes and second menus opens before first is actually closed and NPC menu doesn't open correctly, closePages should be awaited and all works fine.