### PR TITLE
Fix door controller command

### DIFF
--- a/src/core/plugins/core-commands/server/commands/moderator/door.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/door.ts
@@ -16,6 +16,11 @@ Athena.systems.messenger.commands.register('toggledoor', '/toggledoor', ['admin'
         return;
     }
 
+    if (Athena.utility.vector.distance(player.pos, closestDoor.pos) >= 5) {
+        Athena.player.emit.message(player, 'No door in reach found.');
+        return;
+    }
+
     Athena.controllers.doors.update(closestDoor.uid, !closestDoor.isUnlocked);
-    Athena.player.emit.message(player, `Toggling Door ${closestDoor.uid}. Unlocked: ${!closestDoor.isUnlocked}`);
+    Athena.player.emit.message(player, `Toggling Door ${closestDoor.uid}. Unlocked: ${closestDoor.isUnlocked}`);
 });


### PR DESCRIPTION
Fixed an error where the `/toggledoor` command would state the inverse state of the toggled door.
This happened because for the output the value of the `isLocked` variable was inverted after the variable was changed to toggle the lock.

Additionally, I added a check so only doors in a radius of 5 meters can be toggled. After some testing, this seems like an overly excessive distance, but I left it at 5. This distance should be set by the server admin to their liking. 