### PR TITLE
Fixed wrong targeting

### DIFF
--- a/src/core/plugins/core-commands/server/commands/moderator/door.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/door.ts
@@ -16,6 +16,11 @@ Athena.systems.messenger.commands.register('toggledoor', '/toggledoor', ['admin'
         return;
     }
 
+    if (Athena.utility.vector.distance(player.pos, closestDoor.pos) >= 5) {
+        Athena.player.emit.message(player, 'No door in reach found.');
+        return;
+    }
+
     Athena.controllers.doors.update(closestDoor.uid, !closestDoor.isUnlocked);
-    Athena.player.emit.message(player, `Toggling Door ${closestDoor.uid}. Unlocked: ${!closestDoor.isUnlocked}`);
+    Athena.player.emit.message(player, `Toggling Door ${closestDoor.uid}. Unlocked: ${closestDoor.isUnlocked}`);
 });

--- a/src/core/plugins/core-commands/server/commands/moderator/skins.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/skins.ts
@@ -20,7 +20,7 @@ Athena.systems.messenger.commands.register(
             return;
         }
 
-        await Athena.systems.inventory.clothing.setSkin(player, model);
+        await Athena.systems.inventory.clothing.setSkin(target, model);
     },
 );
 


### PR DESCRIPTION
In the command, there is the option to change the skin of another player. However, the old code would always change the skin of the command-executing player, not the targeted one.