### PR TITLE
Fixed: Closest player returned own player

### DIFF
--- a/src/core/server/utility/closest.ts
+++ b/src/core/server/utility/closest.ts
@@ -31,7 +31,7 @@ export function getClosestPlayer(pos: IVector3, ignoredIds: Array<number> = []):
             return false;
         }
 
-        if (ignoredIds.find((x) => x === player.id)) {
+        if (typeof ignoredIds.find((x) => x === player.id) !== 'undefined') {
             return false;
         }
 


### PR DESCRIPTION
If the player had the id 0, the find-Method returned 0 and therefore the player passed the filter accidentially.