### PR TITLE
Fix camera moving in pause menu while noclipping

### DIFF
--- a/src/core/client/systems/noclip.ts
+++ b/src/core/client/systems/noclip.ts
@@ -218,7 +218,9 @@ const NoClip = {
             0,
         );
 
-        NoClip.processCameraRotation();
+        if (!native.isPauseMenuActive()) {
+            NoClip.processCameraRotation();
+        }
     },
 
     // Noclip functions


### PR DESCRIPTION
Before when having noclip on, mouse movement would rotate the camera, even when in the pause menu.

I added an if-statement that checks before wether the menu is open before executing the camera rotation.