### PR TITLE
updated several commands to v5

### DIFF
--- a/src/core/plugins/core-commands/server/commands/moderator/skins.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/skins.ts
@@ -30,6 +30,9 @@ Athena.systems.messenger.commands.register(
     ['admin'],
     async (player: alt.Player, id: string | undefined) => {
         let target = player;
+
+        const hash = typeof target.model === 'number' ? target.model : alt.hash(target.model);
+
         if (typeof id !== 'undefined') {
             target = Athena.systems.identifier.getPlayer(id);
         }
@@ -39,5 +42,9 @@ Athena.systems.messenger.commands.register(
         }
 
         Athena.systems.inventory.clothing.clearSkin(target);
+
+        let pedInfo = Athena.utility.hashLookup.ped.hash(hash);
+
+        Athena.player.emit.message(player, `Skin ${pedInfo.name} was removed.`);
     },
 );

--- a/src/core/plugins/core-commands/server/commands/moderator/test.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/test.ts
@@ -1,18 +1,13 @@
 import * as alt from 'alt-server';
 import * as Athena from '@AthenaServer/api';
-// import { command } from '@AthenaServer/decorators/commands';
-// import { PedController } from '@AthenaServer/streamers/ped';
-// import { WorldNotificationController } from '@AthenaServer/streamers/worldNotifications';
-// import { ServerJobTrigger } from '@AthenaServer/systems/jobTrigger';
 import { WORLD_NOTIFICATION_TYPE } from '@AthenaShared/enums/worldNotificationTypes';
-// import { ANIMATION_FLAGS } from '@AthenaShared/flags/animationFlags';
-// import { PERMISSIONS } from '@AthenaShared/flags/permissionFlags';
-// import { Action } from '@AthenaShared/interfaces/actions';
-// import { Animation } from '@AthenaShared/interfaces/animation';
-// import IAttachable from '@AthenaShared/interfaces/iAttachable';
-// import { InputMenu, InputOptionType, InputResult } from '@AthenaShared/interfaces/inputMenus';
-// import { IPed } from '@AthenaShared/interfaces/iPed';
-// import { JobTrigger } from '@AthenaShared/interfaces/jobTrigger';
+import { ANIMATION_FLAGS } from '@AthenaShared/flags/animationFlags';
+import { Action } from '@AthenaShared/interfaces/actions';
+import { Animation } from '@AthenaShared/interfaces/animation';
+import IAttachable from '@AthenaShared/interfaces/iAttachable';
+import { PedBone } from '@AthenaShared/enums/boneIds';
+import { IPed } from '@AthenaShared/interfaces/iPed';
+import { JobTrigger } from '@AthenaShared/interfaces/jobTrigger';
 
 Athena.systems.messenger.commands.register(
     'timecycle',
@@ -128,232 +123,184 @@ Athena.systems.messenger.commands.register(
     },
 );
 
-// class TestCommands {
-//
-//
+Athena.systems.messenger.commands.register(
+    'testobjectattach',
+    '/testobjectattach - Test object attachment',
+    ['admin'],
+    (player: alt.Player) => {
+        const attachable: IAttachable = {
+            model: 'prop_tool_fireaxe',
+            bone: PedBone.SKEL_R_Hand,
+            pos: {
+                x: 0.1,
+                y: -0.1,
+                z: -0.02,
+            },
+            rot: {
+                x: 80,
+                y: 0,
+                z: 170,
+            },
+        };
 
-//     @command('testinput', '/testinput', PERMISSIONS.ADMIN)
-//     private static testInputCommand(player: alt.Player) {
-//         const menu: InputMenu = {
-//             title: 'Input Test',
-//             options: [
-//                 {
-//                     id: 'some-name',
-//                     desc: 'Write something...',
-//                     placeholder: 'Property Name',
-//                     type: InputOptionType.TEXT,
-//                     error: 'Must specify property name.',
-//                 },
-//                 {
-//                     id: 'some-number',
-//                     desc: 'Some kind of number...',
-//                     placeholder: '5000...',
-//                     type: InputOptionType.NUMBER,
-//                     error: 'Must specify property value.',
-//                 },
-//                 {
-//                     id: 'randomize',
-//                     desc: 'Should this peds apperance be randomized?',
-//                     placeholder: '',
-//                     type: InputOptionType.CHOICE,
-//                     error: '',
-//                     choices: [
-//                         { text: 'Yes', value: 'true' },
-//                         { text: 'No', value: 'false' },
-//                     ],
-//                 },
-//                 {
-//                     id: 'textlabel',
-//                     desc: 'Should this ped have an Textlabel?',
-//                     placeholder: '',
-//                     type: InputOptionType.CHOICE,
-//                     error: '',
-//                     choices: [
-//                         { text: 'Yes', value: 'true' },
-//                         { text: 'No', value: 'false' },
-//                     ],
-//                 },
-//             ],
-//             serverEvent: 'cmd:Input:Test',
-//             generalOptions: {
-//                 submitText: 'Wow Nice Submit',
-//                 cancelText: 'Bad Submit',
-//                 description: 'idk there is some text here now lul',
-//                 skipChecks: false,
-//             },
-//         };
+        Athena.player.emit.objectAttach(player, attachable, 5000);
+    },
+);
 
-//         Athena.player.emit.inputMenu(player, menu);
-//     }
+Athena.systems.messenger.commands.register(
+    'testobjectattachinfinite',
+    '/testobjectattachinfinite - Test object attachment',
+    ['admin'],
+    (player: alt.Player) => {
+        Athena.player.emit.message(player, `Will last for about 5 minutes~`);
 
-//     @command('testobjectattach', '/testobjectattach - Test object attachment', PERMISSIONS.ADMIN)
-//     private static testObjectAttachCommand(player: alt.Player) {
-//         const attachable: IAttachable = {
-//             model: 'prop_tool_fireaxe',
-//             bone: 57005,
-//             pos: {
-//                 x: 0.1,
-//                 y: -0.1,
-//                 z: -0.02,
-//             },
-//             rot: {
-//                 x: 80,
-//                 y: 0,
-//                 z: 170,
-//             },
-//         };
+        const attachable: IAttachable = {
+            model: 'prop_tool_fireaxe',
+            bone: 57005,
+            pos: {
+                x: 0.1,
+                y: -0.1,
+                z: -0.02,
+            },
+            rot: {
+                x: 80,
+                y: 0,
+                z: 170,
+            },
+        };
 
-//         Athena.player.emit.objectAttach(player, attachable, 5000);
-//     }
+        Athena.player.emit.objectAttach(player, attachable, 60000 * 5);
+    },
+);
 
-//     @command('testobjectattachinfinite', '/testobjectattachinfinite - Test object attachment', PERMISSIONS.ADMIN)
-//     private static testObjectAttachInfiniteCommand(player: alt.Player) {
-//         Athena.player.emit.message(player, `Will last for about 5 minutes~`);
+Athena.systems.messenger.commands.register(
+    'testjobmenu',
+    '/testjobmenu - Shows a test job menu',
+    ['admin'],
+    (player: alt.Player) => {
+        const trigger: JobTrigger = {
+            header: 'My Job Header',
+            event: 'job:Example:Response',
+            image: '../../assets/images/job.jpg',
+            summary: `<b>Hey Listen!</b>
+            
+                <p>Isn't it neat that you can write whatever you want here?</p>
+            
+                <p>I sure think so!</p>
+            `,
+            acceptCallback: (player: alt.Player) => {
+                Athena.player.emit.message(player, `You accepted!`);
+            },
+            cancelCallback: (player: alt.Player) => {
+                Athena.player.emit.message(player, `You declined!`);
+            },
+        };
 
-//         const attachable: IAttachable = {
-//             model: 'prop_tool_fireaxe',
-//             bone: 57005,
-//             pos: {
-//                 x: 0.1,
-//                 y: -0.1,
-//                 z: -0.02,
-//             },
-//             rot: {
-//                 x: 80,
-//                 y: 0,
-//                 z: 170,
-//             },
-//         };
+        Athena.systems.jobTrigger.create(player, trigger);
+    },
+);
 
-//         Athena.player.emit.objectAttach(player, attachable, 60000 * 5);
-//     }
+Athena.systems.messenger.commands.register(
+    'testped',
+    '/testped - A Test Ped. Does not delete itself',
+    ['admin'],
+    (player: alt.Player) => {
+        const anim1: Animation = {
+            dict: 'random@arrests@busted',
+            name: 'idle_a',
+            flags: ANIMATION_FLAGS.REPEAT | ANIMATION_FLAGS.UPPERBODY_ONLY,
+            duration: -1,
+        };
 
-//     @command('testjobmenu', '/testjobmenu - Shows a test job menu', PERMISSIONS.ADMIN)
-//     private static testJobMenuCommand(player: alt.Player) {
-//         const trigger: JobTrigger = {
-//             header: 'My Job Header',
-//             event: 'job:Example:Response',
-//             image: '../../assets/images/job.jpg',
-//             summary: `<b>Hey Listen!</b>
+        const anim2: Animation = {
+            dict: 'random@arrests',
+            name: 'idle_2_hands_up',
+            flags: ANIMATION_FLAGS.NORMAL | ANIMATION_FLAGS.STOP_LAST_FRAME,
+            duration: -1,
+        };
 
-//                 <p>Isn't it neat that you can write whatever you want here?</p>
+        const ped: IPed = {
+            uid: `ped-${Math.floor(Math.random() * 500000)}`,
+            model: 'u_f_m_casinocash_01',
+            pos: {
+                x: player.pos.x,
+                y: player.pos.y,
+                z: player.pos.z - 1,
+            },
+            animations: [anim1, anim2],
+        };
 
-//                 <p>I sure think so!</p>
-//             `,
-//             acceptCallback: (player: alt.Player) => {
-//                 Athena.player.emit.message(player, `You accepted!`);
-//             },
-//             cancelCallback: (player: alt.Player) => {
-//                 Athena.player.emit.message(player, `You declined!`);
-//             },
-//         };
+        Athena.controllers.staticPed.append(ped);
+    },
+);
 
-//         ServerJobTrigger.create(player, trigger);
-//     }
+Athena.systems.messenger.commands.register(
+    'testactionmenu',
+    '/testactionmenu - A test action menu',
+    ['admin'],
+    (player: alt.Player) => {
+        // Create an action called facePalm that uses the Animation Interface.
 
-//     @command('testped', '/testped - A Test Ped. Does not delete itself', PERMISSIONS.ADMIN)
-//     private static testPedCommand(player: alt.Player) {
-//         const anim1: Animation = {
-//             dict: 'random@arrests@busted',
-//             name: 'idle_a',
-//             flags: ANIMATION_FLAGS.REPEAT | ANIMATION_FLAGS.UPPERBODY_ONLY,
-//             duration: -1,
-//         };
+        const facePalm: Action = {
+            eventName: 'animation:Action:Server',
+            isServer: true,
+            data: {
+                dict: 'anim@mp_player_intupperface_palm',
+                name: 'idle_a',
+                duration: 3000,
+                flags: ANIMATION_FLAGS.UPPERBODY_ONLY,
+            },
+        };
 
-//         const anim2: Animation = {
-//             dict: 'random@arrests',
-//             name: 'idle_2_hands_up',
-//             flags: ANIMATION_FLAGS.NORMAL | ANIMATION_FLAGS.STOP_LAST_FRAME,
-//             duration: -1,
-//         };
+        // Create an action called gangSign that uses the Animation Interface.
+        const gangSign: Action = {
+            eventName: 'animation:Action:Server',
+            isServer: true,
+            data: {
+                dict: 'mp_player_int_uppergang_sign_a',
+                name: 'mp_player_int_gang_sign_a',
+                duration: 3000,
+                flags: ANIMATION_FLAGS.UPPERBODY_ONLY,
+            },
+        };
 
-//         const ped: IPed = {
-//             uid: `ped-${Math.floor(Math.random() * 500000)}`,
-//             model: 'u_f_m_casinocash_01',
-//             pos: {
-//                 x: player.pos.x,
-//                 y: player.pos.y,
-//                 z: player.pos.z - 1,
-//             },
-//             animations: [anim1, anim2],
-//         };
+        Athena.player.set.actionMenu(
+            player,
+            // The menu
+            {
+                // Option 1 in the menu is a single event.
+                'Option 1': {
+                    eventName: 'hello:From:Client',
+                    isServer: true,
+                },
 
-//         PedController.append(ped);
-//     }
+                // Animations in the menu contains 2 more events. You can also add another menu.
+                Animations: {
+                    'Face Palm': facePalm,
+                    'Gang Sign': gangSign,
+                    // Creates a menu in the menu.
+                    'More Animations': {
+                        'Face Palm 2': facePalm, // Just using the same one for testing purposes
+                        'Gang Sign 2': gangSign,
+                        // Creates a menu in the menu in the menu
+                        'More More Animations': {
+                            'Face Palm 3': facePalm, // Just using the same one for testing purposes
+                            'Gang Sign 3': gangSign,
+                            // etc...
+                        },
+                    },
+                },
+            },
+        );
+    },
+);
 
-//     @command('testactionmenu', '/testactionmenu - A test action menu', PERMISSIONS.ADMIN)
-//     private static testActionMenuCommand(player: alt.Player) {
-//         // Create an action called facePalm that uses the Animation Interface.
-//         const facePalm: Action = {
-//             eventName: 'animation:Action:Server',
-//             isServer: true,
-//             data: {
-//                 dict: 'anim@mp_player_intupperface_palm',
-//                 name: 'idle_a',
-//                 duration: 3000,
-//                 flags: ANIMATION_FLAGS.UPPERBODY_ONLY,
-//             },
-//         };
+alt.onClient('hello:From:Client', (player) => {
+    Athena.player.emit.message(player, `Got menu option from client.`);
+});
 
-//         // Create an action called gangSign that uses the Animation Interface.
-//         const gangSign: Action = {
-//             eventName: 'animation:Action:Server',
-//             isServer: true,
-//             data: {
-//                 dict: 'mp_player_int_uppergang_sign_a',
-//                 name: 'mp_player_int_gang_sign_a',
-//                 duration: 3000,
-//                 flags: ANIMATION_FLAGS.UPPERBODY_ONLY,
-//             },
-//         };
+alt.onClient('animation:Action:Server', (player, data: Animation) => {
+    if (!data) return;
 
-//         // Create the menu and send it to the player/
-//         Athena.player.set.actionMenu(
-//             player,
-//             // The Menu
-//             {
-//                 // Option 1 in the menu is a single event.
-//                 'Option 1': {
-//                     eventName: 'hello:From:Client',
-//                     isServer: true,
-//                 },
-//                 // Animations in the menu contains 2 more events. You can also add another menu.
-//                 Animations: {
-//                     'Face Palm': facePalm,
-//                     'Gang Sign': gangSign,
-//                     // Creates a menu in the menu.
-//                     'More Animations': {
-//                         'Face Palm 2': facePalm, // Just using the same one for testing purposes
-//                         'Gang Sign 2': gangSign,
-//                         // Creates a menu in the menu in the menu
-//                         'More More Animations': {
-//                             'Face Palm 3': facePalm, // Just using the same one for testing purposes
-//                             'Gang Sign 3': gangSign,
-//                             // etc...
-//                         },
-//                     },
-//                 },
-//             },
-//         );
-//     }
-// }
-
-// alt.onClient('cmd:Input:Test', (_player: alt.Player, results: InputResult[] | null) => {
-//     if (!results) {
-//         console.log(`They cancelled the test input.`);
-//         return;
-//     }
-
-//     console.log(`Results from test input:`);
-//     console.log(results);
-// });
-
-// alt.onClient('hello:From:Client', (player) => {
-//     Athena.player.emit.message(player, `Got menu option from client.`);
-// });
-
-// alt.onClient('animation:Action:Server', (player, data: Animation) => {
-//     if (!data) return;
-
-//     Athena.player.emit.animation(player, data.dict, data.name, data.flags, data.duration);
-// });
+    Athena.player.emit.animation(player, data.dict, data.name, data.flags, data.duration);
+});

--- a/src/core/plugins/core-commands/server/commands/moderator/test.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/test.ts
@@ -4,7 +4,7 @@ import * as Athena from '@AthenaServer/api';
 // import { PedController } from '@AthenaServer/streamers/ped';
 // import { WorldNotificationController } from '@AthenaServer/streamers/worldNotifications';
 // import { ServerJobTrigger } from '@AthenaServer/systems/jobTrigger';
-// import { WORLD_NOTIFICATION_TYPE } from '@AthenaShared/enums/worldNotificationTypes';
+import { WORLD_NOTIFICATION_TYPE } from '@AthenaShared/enums/worldNotificationTypes';
 // import { ANIMATION_FLAGS } from '@AthenaShared/flags/animationFlags';
 // import { PERMISSIONS } from '@AthenaShared/flags/permissionFlags';
 // import { Action } from '@AthenaShared/interfaces/actions';
@@ -66,48 +66,71 @@ Athena.systems.messenger.commands.register(
     },
 );
 
+Athena.systems.messenger.commands.register(
+    'testerrorscreen',
+    '/testerrorscreen - Shows a temporary error screen',
+    ['admin'],
+    (player: alt.Player) => {
+        Athena.player.emit.createErrorScreen(player, { duration: 5000, title: 'Test', text: 'Hello World!' });
+    },
+);
+
+Athena.systems.messenger.commands.register(
+    'testworldhelptext',
+    '/testworldhelptext - Shows temporary world help text',
+    ['admin'],
+    (player: alt.Player) => {
+        const uid = Athena.controllers.worldNotification.addToPlayer(player, {
+            text: 'Hello World!',
+            type: WORLD_NOTIFICATION_TYPE.ARROW_BOTTOM,
+            pos: { ...player.pos },
+        });
+
+        alt.setTimeout(() => {
+            if (!player || !player.valid) return;
+            Athena.controllers.worldNotification.removeFromPlayer(player, uid);
+        }, 5000);
+    },
+);
+
+Athena.systems.messenger.commands.register(
+    'testspinner',
+    '/testspinner - Shows a temporary spinner',
+    ['admin'],
+    (player: alt.Player) => {
+        Athena.player.emit.createSpinner(player, { duration: 5000, text: 'Hello World!' });
+    },
+);
+
+Athena.systems.messenger.commands.register(
+    'testshard',
+    '/testshard - Shows a temporary shard',
+    ['admin'],
+    (player: alt.Player) => {
+        Athena.player.emit.createShard(player, {
+            duration: 5000,
+            title: '~r~Hello World!',
+            text: '~y~Shards are pretty neat sometimes.',
+        });
+    },
+);
+
+Athena.systems.messenger.commands.register(
+    'testcredits',
+    '/testcredits - Shows a temporary credits display',
+    ['admin'],
+    (player: alt.Player) => {
+        Athena.player.emit.createCredits(player, {
+            duration: 5000,
+            role: 'Athena Creator',
+            name: 'Stuyk',
+        });
+    },
+);
+
 // class TestCommands {
-//     @command('testerrorscreen', '/testerrorscreen - Shows a temporary error screen', PERMISSIONS.ADMIN)
-//     private static testErrorScreen(player: alt.Player) {
-//         Athena.player.emit.createErrorScreen(player, { duration: 5000, title: 'Test', text: 'Hello World!' });
-//     }
-
-//     @command('testworldhelptext', '/testworldhelptext - Shows temporary world help text', PERMISSIONS.ADMIN)
-//     private static testWorldHelpTextComamnd(player: alt.Player) {
-//         const uid = WorldNotificationController.addToPlayer(player, {
-//             text: 'Hello World!',
-//             type: WORLD_NOTIFICATION_TYPE.ARROW_BOTTOM,
-//             pos: { ...player.pos },
-//         });
-
-//         alt.setTimeout(() => {
-//             if (!player || !player.valid) return;
-//             WorldNotificationController.removeFromPlayer(player, uid);
-//         }, 5000);
-//     }
-
-//     @command('testspinner', '/testspinner - Shows a temporary spinner', PERMISSIONS.ADMIN)
-//     private static testSpinnerCommand(player: alt.Player) {
-//         Athena.player.emit.createSpinner(player, { duration: 5000, text: 'Hello World!' });
-//     }
-
-//     @command('testshard', '/testshard - Shows a temporary shard', PERMISSIONS.ADMIN)
-//     private static testShardCommand(player: alt.Player) {
-//         Athena.player.emit.createShard(player, {
-//             duration: 5000,
-//             title: '~r~Hello World!',
-//             text: '~y~Shards are pretty neat sometimes.',
-//         });
-//     }
-
-//     @command('testcredits', '/testcredits - Shows a temporary credits display', PERMISSIONS.ADMIN)
-//     private static testCreditsCommand(player: alt.Player) {
-//         Athena.player.emit.createCredits(player, {
-//             duration: 5000,
-//             role: 'Athena Creator',
-//             name: 'Stuyk',
-//         });
-//     }
+//
+//
 
 //     @command('testinput', '/testinput', PERMISSIONS.ADMIN)
 //     private static testInputCommand(player: alt.Player) {

--- a/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
@@ -3,6 +3,8 @@ import * as Athena from '@AthenaServer/api';
 import { LOCALE_KEYS } from '@AthenaShared/locale/languages/keys';
 import { LocaleController } from '@AthenaShared/locale/locale';
 import { VehicleState } from '@AthenaShared/interfaces/vehicleState';
+import IVehicleTuning from '@AthenaShared/interfaces/vehicleTuning';
+import IVehicleMod from '@AthenaShared/interfaces/vehicleMod';
 
 Athena.systems.messenger.commands.register(
     'tempvehicle',
@@ -114,6 +116,10 @@ function setLivery(player: alt.Player, livery: number) {
     Athena.vehicle.controls.updateLastUsed(vehicle);
     Athena.vehicle.controls.update(vehicle);
 
+    var tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
+
+    Athena.document.vehicle.set(vehicle, 'tuning', tuningData);
+
     const hash = typeof vehicle.model === 'number' ? vehicle.model : alt.hash(vehicle.model);
 
     let vehInfo = Athena.utility.hashLookup.vehicle.hash(hash);
@@ -219,6 +225,10 @@ Athena.systems.messenger.commands.register(
         }
         Athena.vehicle.controls.updateLastUsed(vehicle);
         Athena.vehicle.controls.update(vehicle);
+
+        var tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
+
+        Athena.document.vehicle.set(vehicle, 'tuning', tuningData);
     },
 );
 

--- a/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
@@ -101,9 +101,16 @@ function setLivery(player: alt.Player, livery: number) {
         return;
     }
 
-    const liveryState: Partial<VehicleState> = { livery };
+    if (vehicle.modKit == 0 && vehicle.modKitsCount > 0) {
+        Athena.vehicle.tuning.applyTuning(vehicle, { modkit: 1 });
+    }
 
-    Athena.vehicle.tuning.applyState(vehicle, liveryState);
+    if (vehicle.modKit == 0) {
+        Athena.player.emit.message(player, LocaleController.get(LOCALE_KEYS.VEHICLE_HAS_NO_MOD_KIT));
+        return;
+    }
+
+    Athena.vehicle.tuning.applyTuning(vehicle, { mods: [{ id: 48, value: livery }] });
     Athena.vehicle.controls.updateLastUsed(vehicle);
     Athena.vehicle.controls.update(vehicle);
 
@@ -202,12 +209,16 @@ Athena.systems.messenger.commands.register(
         for (let i = 0; i < 70; ++i) {
             const maxId = vehicle.getModsCount(i);
 
+            if (i == 48) {
+                continue;
+            }
+
             if (maxId > 0) {
                 Athena.vehicle.tuning.applyTuning(vehicle, { mods: [{ id: i, value: maxId }] });
-                Athena.vehicle.controls.updateLastUsed(vehicle);
-                Athena.vehicle.controls.update(vehicle);
             }
         }
+        Athena.vehicle.controls.updateLastUsed(vehicle);
+        Athena.vehicle.controls.update(vehicle);
     },
 );
 

--- a/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
@@ -9,6 +9,11 @@ Athena.systems.messenger.commands.register(
     '/tempvehicle [model] - Adds a temporary vehicle to drive around. Despawns on exit.',
     ['admin'],
     (player: alt.Player, model: string) => {
+        if (!model) {
+            Athena.player.emit.message(player, `No model specified.`);
+            return;
+        }
+
         const vehicle = Athena.vehicle.spawn.temporary({ model, pos: player.pos, rot: player.rot }, true);
         if (!vehicle) {
             return;
@@ -24,6 +29,7 @@ Athena.systems.messenger.commands.register(
     ['admin'],
     (player: alt.Player, model: string) => {
         if (!model) {
+            Athena.player.emit.message(player, `No model specified.`);
             return;
         }
 
@@ -148,6 +154,25 @@ function setVehicleDirtlevel(player: alt.Player, dirtLevel: number) {
     Athena.player.emit.message(player, `Dirtlevel of ${vehInfo.displayName} was set to ID ${dirtLevel}.`);
 }
 
+Athena.systems.messenger.commands.register(
+    'sessionvehicle',
+    LocaleController.get(LOCALE_KEYS.COMMAND_SESSION_VEHICLE, '/sessionvehicle'),
+    ['admin'],
+    (player: alt.Player, model: string) => {
+        if (!model) {
+            Athena.player.emit.message(player, `No model specified.`);
+            return;
+        }
+
+        const vehicle = Athena.vehicle.spawn.temporary({ model, pos: player.pos, rot: player.rot }, false);
+        if (!vehicle) {
+            return;
+        }
+
+        player.setIntoVehicle(vehicle, Athena.vehicle.shared.SEAT.DRIVER);
+    },
+);
+
 //@command(
 //         ['fullTuneVehicle', 'ft'],
 //         LocaleController.get(LOCALE_KEYS.COMMAND_FULL_TUNE_VEHICLE, '/ft'),
@@ -186,20 +211,8 @@ function setVehicleDirtlevel(player: alt.Player, dirtLevel: number) {
 // import { getClosestEntity } from '@AthenaServer/utility/vector';
 
 // class VehicleCommands {
-//     @command(
-//         'refillVehicle',
-//         LocaleController.get(LOCALE_KEYS.COMMAND_REFILL_VEHICLE, '/refillVehicle'),
-//         PERMISSIONS.ADMIN,
-//     )
-//     private static refillVehicleCommand(player: alt.Player) {
-//         if (!player.vehicle || !player.vehicle.data.fuel) {
-//             return;
-//         }
-//         player.vehicle.data.fuel = 100;
-//         Athena.vehicle.funcs.save(player.vehicle, player.vehicle.data);
-//         Athena.player.emit.notification(player, LocaleController.get(LOCALE_KEYS.VEHICLE_REFILLED));
-//     }
 //
+
 //     @command(
 //         ['setVehicleHandling', 'sh'],
 //         LocaleController.get(LOCALE_KEYS.COMMAND_SET_VEHICLE_HANDLING, '/sh'),
@@ -215,29 +228,6 @@ function setVehicleDirtlevel(player: alt.Player, dirtLevel: number) {
 //         vehicle.data.tuning.handling[key] = nValue;
 //         vehicle.setStreamSyncedMeta('handlingData', vehicle.data.tuning.handling);
 //         Athena.vehicle.funcs.save(vehicle, vehicle.data);
-//     }
-
-//     @command(
-//         'sessionvehicle',
-//         LocaleController.get(LOCALE_KEYS.COMMAND_SESSION_VEHICLE, '/sessionvehicle'),
-//         PERMISSIONS.ADMIN,
-//     )
-//     private static createSessionVehicle(player: alt.Player, model: string): void {
-//         let vehicle: alt.Vehicle;
-//         try {
-//             vehicle = Athena.vehicle.funcs.sessionVehicle(player, model, player.pos, new alt.Vector3(0, 0, 0));
-//         } catch (err) {
-//             Athena.player.emit.message(player, LocaleController.get(LOCALE_KEYS.VEHICLE_MODEL_INVALID));
-//         }
-//         if (!vehicle) {
-//             return;
-//         }
-
-//         Athena.player.emit.message(player, LocaleController.get(LOCALE_KEYS.VEHICLE_CREATED));
-
-//         alt.nextTick(() => {
-//             player.setIntoVehicle(vehicle, 1);
-//         });
 //     }
 
 //     @command(

--- a/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
@@ -173,36 +173,43 @@ Athena.systems.messenger.commands.register(
     },
 );
 
-//@command(
-//         ['fullTuneVehicle', 'ft'],
-//         LocaleController.get(LOCALE_KEYS.COMMAND_FULL_TUNE_VEHICLE, '/ft'),
-//         PERMISSIONS.ADMIN,
-//     )
-//     private static fullTuneVehicleCommand(player: alt.Player): void {
-//         const vehicle = player.vehicle;
-//         if (!vehicle?.valid || !vehicle?.data) return;
+Athena.systems.messenger.commands.register(
+    'fullTuneVehicle',
+    LocaleController.get(LOCALE_KEYS.COMMAND_FULL_TUNE_VEHICLE, '/fullTuneVehicle'),
+    ['admin'],
+    (player: alt.Player) => {
+        const vehicle = player.vehicle ? player.vehicle : Athena.utility.closest.getClosestVehicle(player.pos);
 
-//         if (!vehicle.data.tuning) vehicle.data.tuning = {};
-//         delete vehicle.data.tuning.mods;
+        if (!vehicle) {
+            Athena.player.emit.message(player, 'No spawned vehicle.');
+            return;
+        }
 
-//         if (vehicle.modKit == 0 && vehicle.modKitsCount > 0) Athena.vehicle.funcs.setModKit(vehicle, 1);
+        if (Athena.utility.vector.distance(player.pos, vehicle.pos) > 4) {
+            Athena.player.emit.message(player, 'No vehicle in range.');
+            return;
+        }
 
-//         if (vehicle.modKit == 0) {
-//             Athena.player.emit.message(player, LocaleController.get(LOCALE_KEYS.VEHICLE_HAS_NO_MOD_KIT));
-//             return;
-//         }
+        if (vehicle.modKit == 0 && vehicle.modKitsCount > 0) {
+            Athena.vehicle.tuning.applyTuning(vehicle, { modkit: 1 });
+        }
 
-//         for (let i = 0; i < 70; ++i) {
-//             const maxId = vehicle.getModsCount(i);
+        if (vehicle.modKit == 0) {
+            Athena.player.emit.message(player, LocaleController.get(LOCALE_KEYS.VEHICLE_HAS_NO_MOD_KIT));
+            return;
+        }
 
-//             if (maxId > 0) {
-//                 Athena.vehicle.funcs.setMod(vehicle, i, maxId);
-//             }
-//         }
+        for (let i = 0; i < 70; ++i) {
+            const maxId = vehicle.getModsCount(i);
 
-//         console.log(vehicle.data);
-//         Athena.vehicle.funcs.save(vehicle, vehicle.data);
-//     }
+            if (maxId > 0) {
+                Athena.vehicle.tuning.applyTuning(vehicle, { mods: [{ id: i, value: maxId }] });
+                Athena.vehicle.controls.updateLastUsed(vehicle);
+                Athena.vehicle.controls.update(vehicle);
+            }
+        }
+    },
+);
 
 // import { command } from '@AthenaServer/decorators/commands';
 // import { PERMISSIONS } from '@AthenaShared/flags/permissionFlags';

--- a/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
+++ b/src/core/plugins/core-commands/server/commands/moderator/vehicle.ts
@@ -116,7 +116,7 @@ function setLivery(player: alt.Player, livery: number) {
     Athena.vehicle.controls.updateLastUsed(vehicle);
     Athena.vehicle.controls.update(vehicle);
 
-    var tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
+    const tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
 
     Athena.document.vehicle.set(vehicle, 'tuning', tuningData);
 
@@ -226,7 +226,7 @@ Athena.systems.messenger.commands.register(
         Athena.vehicle.controls.updateLastUsed(vehicle);
         Athena.vehicle.controls.update(vehicle);
 
-        var tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
+        const tuningData: IVehicleTuning = Athena.vehicle.tuning.getTuning(vehicle);
 
         Athena.document.vehicle.set(vehicle, 'tuning', tuningData);
     },

--- a/src/core/server/vehicle/tuning.ts
+++ b/src/core/server/vehicle/tuning.ts
@@ -60,10 +60,10 @@ export function getTuning(vehicle: alt.Vehicle): VehicleTuning {
         return Overrides.getTuning(vehicle);
     }
 
-    var tuningData: VehicleTuning = { modkit: vehicle.modKit, mods: [] };
+    let tuningData: VehicleTuning = { modkit: vehicle.modKit, mods: [] };
 
     for (let id = 0; id < 70; ++id) {
-        var value = vehicle.getMod(id);
+        let value = vehicle.getMod(id);
         tuningData.mods.push({ id, value });
     }
 

--- a/src/core/server/vehicle/tuning.ts
+++ b/src/core/server/vehicle/tuning.ts
@@ -48,15 +48,39 @@ export function applyTuning(vehicle: alt.Vehicle, tuning: VehicleTuning | Partia
     }
 }
 
+/**
+ * Get all mods of the specified vehicle.
+ *
+ *
+ * @param {alt.Vehicle} vehicle An alt:V Vehicle Entity
+ * @param {VehicleTuning } tuning
+ */
+export function getTuning(vehicle: alt.Vehicle): VehicleTuning {
+    if (Overrides.getTuning) {
+        return Overrides.getTuning(vehicle);
+    }
+
+    var tuningData: VehicleTuning = { modkit: vehicle.modKit, mods: [] };
+
+    for (let id = 0; id < 70; ++id) {
+        var value = vehicle.getMod(id);
+        tuningData.mods.push({ id, value });
+    }
+
+    return tuningData;
+}
+
 interface VehicleTuningFuncs {
     applyState: typeof applyState;
     applyTuning: typeof applyTuning;
+    getTuning: typeof getTuning;
 }
 
 const Overrides: Partial<VehicleTuningFuncs> = {};
 
 export function override(functionName: 'applyState', callback: typeof applyState);
 export function override(functionName: 'applyTuning', callback: typeof applyTuning);
+export function override(functionName: 'getTuning', callback: typeof getTuning);
 /**
  * Used to override vehicle tuning functionality
  *


### PR DESCRIPTION
List of commands updated to v5:

- /testerrorscreen
- /testworldhelptext
- /testspinner
- /testshard
- /testcredits
- /testobjectattach
- /testobjectattachinfinite
- /testjobmenu
- /testped
- /testactionmenu



- /fullTuneVehicle
- /sessionvehicle
- /setVehicleLivery & /svl
- /setvehicledirtLevel & /svdl


Also updated the vehicleRepair command to update the lastUsed value, all vehicle-creation commands to tell the user if no model was specified and the clearSkin command to tell the user the name of the removed skin.

Currently the vehicleHandling and neonLight commands are not updated. This is due to the needed systems not being in place yet.