### PR TITLE
Fixed argument in playAnimation for static peds

### DIFF
--- a/src/core/server/controllers/staticPed.ts
+++ b/src/core/server/controllers/staticPed.ts
@@ -153,21 +153,21 @@ export function addToPlayer(player: alt.Player, pedData: IPed): string {
  *
  * #### Example
  * ```ts
- * Athena.controllers.staticPed.playAnimation('the-id-you-specified', playAnimation('test', [
+ * Athena.controllers.staticPed.playAnimation('the-id-you-specified', playAnimation('test',
  *      {
  *          dict: 'mp_ped_interaction',
  *          name: 'hugs_guy_a',
  *          duration: 2000,
  *          flags: 0,
  *      },
- * ]);
+ * );
  * ```
  *
  *
  * @param {string} uid A unique string
- * @param {Animation[]} animation
+ * @param {Animation} animation
  */
-export function playAnimation(uid: string, animation: Animation[]) {
+export function playAnimation(uid: string, animation: Animation) {
     alt.emitAllClients(SYSTEM_EVENTS.PLAY_ANIMATION_FOR_PED, uid, animation);
 }
 


### PR DESCRIPTION
The ``animation`` argument was typed as an array. If it was intended to be an array, it is not handled correctly on the client-side, so animations for static ped simply did not work.