### PR TITLE
Fixed: Vehicle menu not locking/unlocking

### DIFF
--- a/src/core/client/menus/vehicle.ts
+++ b/src/core/client/menus/vehicle.ts
@@ -115,7 +115,9 @@ export function open(vehicle: alt.Vehicle) {
         name: isLocked ? 'Unlock' : 'Lock',
         color: isLocked ? 'green' : 'red',
         icon: isLocked ? 'icon-lock-open' : 'icon-lock',
-        emitServer: VEHICLE_EVENTS.SET_LOCK,
+        callback() {
+            alt.emitServer(VEHICLE_EVENTS.SET_LOCK, vehicle);
+        },
     });
 
     // Not Pushing & Vehicle is Currently Unlocked


### PR DESCRIPTION
Before: When standing outside of a vehicle and opening the vehicle wheel menu, nothing did happen on lock/unlock menu action.

Reason: The emit to the server didn't send the vehicle property with it, so the server just checked for the vehicle a player is sitting in.

After: The emit includes the selected vehicle entity and the lock/unlock menu action works properly. 