### PR TITLE
Fix error when meta is uninitialized

### DIFF
--- a/src/core/client/webview/index.ts
+++ b/src/core/client/webview/index.ts
@@ -678,7 +678,7 @@ export function isAnyMenuOpen(excludeDead = false): boolean {
     }
 
     if (!excludeDead) {
-        if (alt.Player.local.meta.isDead) {
+        if (alt.Player.local.meta?.isDead) {
             return true;
         }
     }


### PR DESCRIPTION
When the player local meta is not initialized, a page is created and the page is opened to report an error: Cannot read properties of undefined (reading 'isDead')