### PR TITLE
Reset optionIndex when initiating a menu3d

### DIFF
--- a/src/core/client/rmlui/menu3d/index.ts
+++ b/src/core/client/rmlui/menu3d/index.ts
@@ -27,6 +27,7 @@ const InternalFunctions = {
         internalOptions = options;
         internalPos = pos;
         maxDistance = distance;
+        optionIndex = 0;
 
         // Options Setup
         const optionsElement = document.getElementByID('options');


### PR DESCRIPTION
Previously after selecting an option that's not the first one, creating new menu and clicking arrow up or down, two options would be selected. Resetting the index fixes that.