### PR TITLE
fix sorting for entity selection to prevent closest target beeing filterted out

### DIFF
--- a/src/core/client/systems/entitySelector.ts
+++ b/src/core/client/systems/entitySelector.ts
@@ -89,7 +89,7 @@ const Internal = {
             entityInfo.push({ dist, height: 1, id: -1, pos: latestInteraction.position, type: 'interaction' });
         }
 
-        entityInfo.sort((a, b) => {
+        entityInfo = entityInfo.sort((a, b) => {
             return a.dist - b.dist;
         });
 


### PR DESCRIPTION
witout this it can happen that the entityInfo of the target right next to you is filtered out