### PR TITLE
Override AthenaClient.webview.on functions

### DIFF
--- a/src/core/client/webview/index.ts
+++ b/src/core/client/webview/index.ts
@@ -603,12 +603,16 @@ export function ready(pageName: string, callback: AnyCallback) {
  * @param {(...args: any[]) => void} callback
  *
  */
-export function on<EventNames = string>(eventName: EventNames, callback: AnyCallback) {
+export function on<EventNames = string>(eventName: EventNames, callback: AnyCallback, overide: boolean = false) {
     if (ClientEvents[String(eventName)]) {
-        console.warn(`[Client] Duplicate Event Name (${eventName}) for Athena.webview.on (WebViewController.onInvoke)`);
-
-        console.warn(`Did not register duplicate event.`);
-        return;
+        if (override) {
+            delete ClientEvents[String(eventName)];
+        } else {  
+            console.warn(`[Client] Duplicate Event Name (${eventName}) for Athena.webview.on (WebViewController.onInvoke)`);
+    
+            console.warn(`Did not register duplicate event.`);
+            return;
+        }
     }
 
     ClientEvents[String(eventName)] = callback;


### PR DESCRIPTION
Lets us override AthenaClient.webview.on functions. 

Just had the problem that i searched for hours why my Plugin keeps using an old value until i found out that the ClientEvents gets cached. 

Maybe there is another better work around than this pull if yes please lmk and close it.